### PR TITLE
Add arXiv paper link and citation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Aero Hand Overview](assets/banner.png)
 
 <p align="center">
+  <a href="https://arxiv.org/abs/2608.28578"><img src="https://img.shields.io/badge/arXiv-2608.28578-b31b1b?logo=arxiv" alt="arXiv"></a>
   <a href="https://tetheria.github.io/aero-hand-open/"><img src="https://img.shields.io/badge/project-page-brightgreen" alt="Project Page"></a>
   <a href="https://docs.tetheria.ai/"><img src="https://img.shields.io/badge/doc-page-orange" alt="Documentation"></a>
   <!-- <a href="https://github.com/TetherIA/aero-hand-open/issues"><img src="https://img.shields.io/github/issues/RoboVerseOrg/RoboVerse?color=yellow" alt="Issues"></a> -->
@@ -16,6 +17,7 @@ Aero Hand Open is an **open-source**, **tendon-driven** robotic hand designed an
 
 Each joint is optimized for mechanical efficiency through tendon actuation, enabling smooth and natural motion while maintaining a **lightweight** and **compact** design, making it perfect for research labs, educational institutions, and robotics enthusiasts who need an **affordable** yet **capable** manipulation platform.
 
+> **📄 Paper:** [Aero Hand Open: A Simulation-Ready Tendon-Driven Hand for Dexterous Manipulation Learning](https://arxiv.org/abs/2608.28578) (arXiv:2608.28578)   
 > **📚 Learn More:** https://tetheria.github.io/aero-hand-open/   
 > **🛒 Shop:** https://shop.tetheria.ai/
 
@@ -43,6 +45,7 @@ Each joint is optimized for mechanical efficiency through tendon actuation, enab
   - [Simulation](#simulation)
   - [Reinforcement Learning](#reinforcement-learning-tools)
 - [Getting help](#Getting-help)
+- [Citation](#citation)
 - [License — TL;DR](#license--tldr)
 - [Disclaimer](#disclaimer)
 - [Project Updates & Community](#project-updates--community)
@@ -162,6 +165,25 @@ An example of deploying trained policies in ROS is also provided in the [`ros2/`
 - Quick questions, live debugging, voice/screen‑share
 - Social chat, lab intros, "I printed my first hand!"
 - Live events and office hours
+
+# Citation
+
+If you use Aero Hand Open in your research, please cite our paper:
+
+> Nan Wang, Mohit Yadav, Jonathan Wulff, Aidan Rosenbaum, Kezhou Chen, Yuvan Sharma, Xu Dong, Yiwei Tao.
+> **Aero Hand Open: A Simulation-Ready Tendon-Driven Hand for Dexterous Manipulation Learning.** arXiv:2608.28578, 2026.
+> [📄 arXiv](https://arxiv.org/abs/2608.28578) · [PDF](https://arxiv.org/pdf/2608.28578)
+
+```bibtex
+@article{wang2026aerohandopen,
+  title   = {Aero Hand Open: A Simulation-Ready Tendon-Driven Hand for Dexterous Manipulation Learning},
+  author  = {Wang, Nan and Yadav, Mohit and Wulff, Jonathan and Rosenbaum, Aidan and
+             Chen, Kezhou and Sharma, Yuvan and Dong, Xu and Tao, Yiwei},
+  journal = {arXiv preprint arXiv:2608.28578},
+  year    = {2026},
+  url     = {https://arxiv.org/abs/2608.28578}
+}
+```
 
 # License — TL;DR
 


### PR DESCRIPTION
The work is now published: [arXiv:2608.28578](https://arxiv.org/abs/2608.28578) — *Aero Hand Open: A Simulation-Ready Tendon-Driven Hand for Dexterous Manipulation Learning* (Wang, Yadav, Wulff, Rosenbaum, Chen, Sharma, Dong, Tao).

## Changes to `README.md`
- arXiv badge, first in the badge row
- **📄 Paper** quick-link above the existing Learn More / Shop links
- New **Citation** section (before License) with the plain-text reference and the BibTeX entry, plus a TOC entry

## Related
The project page was updated in the same pass — pushed directly to `gh-pages` (526ab49), since that branch is the deploy target and its history is all direct commits. That change adds a "Paper (arXiv)" button to the hero row, updates the BibTeX block to the published citation, and fills in the Google Scholar `citation_*` meta tags and the JSON-LD `identifier`/`sameAs`.

## Testing
Docs only — no code touched, nothing to run on hardware. Paper metadata (title, author list, date, arXiv ID) was read off the arXiv abstract page. The gh-pages counterpart was rendered locally at 1280px and 375px to confirm the new button and the reflowed BibTeX block fit without overflow, and both JSON-LD blocks still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)